### PR TITLE
🪄 Fix typo in description

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 lua54 'yes'
 use_fxv2_oal 'yes'
 
-description 'NextCitizen, an powerfull FiveM framework RolePlay-Based'
+description 'NextCitizen, a powerful FiveM framework RolePlay-Based'
 version '1.0.0-alpha'
 
 --[[


### PR DESCRIPTION
The rule is that you use “a" before words that start with a consonant sound and “an” before words that start with a vowel sound. Also "powerfull" is not a word in English, it's "powerful" ^^