### PR TITLE
✏️ Set same typos/conventions codes for every files.

### DIFF
--- a/src/api/ped/client/clearPed.lua
+++ b/src/api/ped/client/clearPed.lua
@@ -4,8 +4,9 @@
 ---@public
 function API_Ped:clearPed(pedId)
   if (not (DoesEntityExist(pedId))) then
-    return NCS:die("Target ped does not exists")
+    return NCS:die("Target ped doesn't exist")
   end
+
   ClearPedProp(pedId,0)
   ClearPedBloodDamage(pedId)
   ClearPedTasksImmediately(pedId)

--- a/src/api/ped/client/driveVehicle.lua
+++ b/src/api/ped/client/driveVehicle.lua
@@ -3,6 +3,10 @@
 ---@return boolean, number
 ---@public
 function API_Ped:driveVehicle(pedId)
+    if (not (DoesEntityExist(pedId))) then
+        return NCS:die("Target ped doesn't exist")
+    end
+
     local inVehicle = IsPedInAnyVehicle(pedId, false)
     if (not inVehicle) then
         return nil, nil

--- a/src/api/ped/client/getDistance.lua
+++ b/src/api/ped/client/getDistance.lua
@@ -4,6 +4,10 @@
 ---@return number
 ---@public
 function API_Ped:getDistance(pedId, coords)
+    if (not (DoesEntityExist(pedId))) then
+        return NCS:die("Target ped doesn't exist")
+    end
+
     local distance <const> = #(API_Ped:getPosition(pedId) - coords)
     return (distance)
 end

--- a/src/api/ped/client/getHeading.lua
+++ b/src/api/ped/client/getHeading.lua
@@ -4,7 +4,7 @@
 ---@public
 function API_Ped:getHeading(pedId)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     return (GetEntityHeading(pedId))

--- a/src/api/ped/client/getHealth.lua
+++ b/src/api/ped/client/getHealth.lua
@@ -4,7 +4,7 @@
 ---@public
 function API_Ped:getHealth(pedId)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     return (GetEntityHealth(pedId))

--- a/src/api/ped/client/getMugshot.lua
+++ b/src/api/ped/client/getMugshot.lua
@@ -5,8 +5,9 @@
 ---@public
 function API_Ped:getMugshot(pedId, transparentBackground)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
+
     local headshot = (transparentBackground) and RegisterPedheadshotTransparent(pedId) or RegisterPedheadshot(pedId)
     while (not IsPedheadshotReady(headshot) and not IsPedHeadshotValid(headshot)) do
         Wait(0)

--- a/src/api/ped/client/getNearestCoords.lua
+++ b/src/api/ped/client/getNearestCoords.lua
@@ -5,6 +5,10 @@
 ---@return any
 ---@public
 function API_Ped:getNearestCoords(pedId, coords, radius)
+  if (not (DoesEntityExist(pedId))) then
+    return NCS:die("Target ped doesn't exist")
+  end
+
   local nearestCoords = API_Ped:getPosition(pedId)
   local currentCoords = radius or 5000
 

--- a/src/api/ped/client/getPosition.lua
+++ b/src/api/ped/client/getPosition.lua
@@ -4,8 +4,8 @@
 ---@public
 function API_Ped:getPosition(pedId)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
-    end    
+        return NCS:die("Target ped doesn't exist")
+    end
     
     return (GetEntityCoords(pedId))
 end

--- a/src/api/ped/client/giveWeapon.lua
+++ b/src/api/ped/client/giveWeapon.lua
@@ -8,7 +8,7 @@
 ---@public
 function API_Ped:giveWeapon(pedId, weaponName, ammo, isHidden, forceInHand)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
     
     local weaponHash = GetHashKey(weaponName)

--- a/src/api/ped/client/giveWeaponComponent.lua
+++ b/src/api/ped/client/giveWeaponComponent.lua
@@ -5,7 +5,7 @@
 ---@public
 function API_Ped:giveWeaponComponent(pedId, weaponName, componentName)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
     
     local weaponHash <const> = GetHashKey(weaponName)

--- a/src/api/ped/client/hasWeapon.lua
+++ b/src/api/ped/client/hasWeapon.lua
@@ -5,7 +5,7 @@
 ---@public
 function API_Ped:hasWeapon(pedId, weaponName)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
     
     return (HasPedGotWeapon(pedId, weaponName, false) == 1)

--- a/src/api/ped/client/hasWeaponComponent.lua
+++ b/src/api/ped/client/hasWeaponComponent.lua
@@ -6,7 +6,7 @@
 ---@public
 function API_Ped:hasWeaponComponent(pedId, weaponName, componentName)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
     
     return (HasPedGotWeaponComponent(pedId, weaponName, componentName, false) == 1)

--- a/src/api/ped/client/isDead.lua
+++ b/src/api/ped/client/isDead.lua
@@ -4,7 +4,7 @@
 ---@public
 function API_Ped:isDead(pedId)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     return (API_Ped:getHealth(pedId) <= 0)

--- a/src/api/ped/client/kill.lua
+++ b/src/api/ped/client/kill.lua
@@ -4,7 +4,7 @@
 ---@public
 function API_Ped:kill(pedId)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     SetEntityHealth(pedId, 0)

--- a/src/api/ped/client/leaveVehicle.lua
+++ b/src/api/ped/client/leaveVehicle.lua
@@ -5,7 +5,7 @@
 ---@public
 function API_Ped:leaveVehicle(pedId, instant)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     TaskLeaveAnyVehicle(pedId, 0, instant and 16 or 0)

--- a/src/api/ped/client/playAnimation.lua
+++ b/src/api/ped/client/playAnimation.lua
@@ -11,7 +11,7 @@
 ---@public
 function API_Ped:playAnimation(pedId, dict, anim, flag, blendin, blendout, playbackRate, duration)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     blendin = blendin or 1.0

--- a/src/api/ped/client/removeWeapon.lua
+++ b/src/api/ped/client/removeWeapon.lua
@@ -5,8 +5,9 @@
 ---@public
 function API_Ped:removeWeapon(pedId, weaponName)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
+
     local weaponHash = GetHashKey(weaponName)
     RemoveWeaponFromPed(pedId, weaponHash)
 end

--- a/src/api/ped/client/removeWeaponComponent.lua
+++ b/src/api/ped/client/removeWeaponComponent.lua
@@ -5,8 +5,9 @@
 ---@public
 function API_Ped:removeWeaponComponent(pedId, weaponName, componentName)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
+
     local weaponHash = GetHashKey(weaponName)
     if API_Ped:hasWeapon(pedId, weaponHash) and API_Ped:hasWeaponComponent(pedId, weaponHash, componentName) then
         RemoveWeaponComponentFromPed(pedId, weaponHash, componentName)

--- a/src/api/ped/client/resetAlhpa.lua
+++ b/src/api/ped/client/resetAlhpa.lua
@@ -4,7 +4,7 @@
 ---@public
 function API_Ped:resetAlpha(pedId)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     ResetEntityAlpha(pedId)

--- a/src/api/ped/client/setAlhpa.lua
+++ b/src/api/ped/client/setAlhpa.lua
@@ -5,7 +5,7 @@
 ---@public
 function API_Ped:setAlpha(pedId, value)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     SetEntityAlpha(pedId, value, false)

--- a/src/api/ped/client/setFreeze.lua
+++ b/src/api/ped/client/setFreeze.lua
@@ -5,8 +5,8 @@
 ---@public
 function API_Ped:setFreeze(pedId, state)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
-    end    
+        return NCS:die("Target ped doesn't exist")
+    end
     
     FreezeEntityPosition(pedId, state)
 end

--- a/src/api/ped/client/setHeading.lua
+++ b/src/api/ped/client/setHeading.lua
@@ -5,8 +5,8 @@
 ---@public
 function API_Ped:setHeading(pedId, heading)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
-    end    
+        return NCS:die("Target ped doesn't exist")
+    end
     
     SetEntityHeading(pedId, heading)
 end

--- a/src/api/ped/client/setHealth.lua
+++ b/src/api/ped/client/setHealth.lua
@@ -5,7 +5,7 @@
 ---@public
 function API_Ped:setHealth(pedId, value)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     SetEntityHealth(pedId, value)

--- a/src/api/ped/client/setIntoVehicle.lua
+++ b/src/api/ped/client/setIntoVehicle.lua
@@ -5,7 +5,7 @@
 ---@public
 function API_Ped:setIntoVehicle(pedId, vehicleId, seat)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     TaskWarpPedIntoVehicle(pedId, vehicleId, seat or -1)

--- a/src/api/ped/client/setInvincible.lua
+++ b/src/api/ped/client/setInvincible.lua
@@ -5,8 +5,8 @@
 ---@public
 function API_Ped:setInvincible(pedId, state)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
-    end    
+        return NCS:die("Target ped doesn't exist")
+    end
     
     SetEntityInvincible(pedId, state)
 end

--- a/src/api/ped/client/setMaxHealth.lua
+++ b/src/api/ped/client/setMaxHealth.lua
@@ -5,7 +5,7 @@
 ---@public
 function API_Ped:setMaxHealth(pedId, value)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
 
     SetEntityMaxHealth(pedId, value)

--- a/src/api/ped/client/setPosition.lua
+++ b/src/api/ped/client/setPosition.lua
@@ -6,8 +6,8 @@
 ---@public
 function API_Ped:setPosition(pedId, coords, keepVehicle)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
-    end    
+        return NCS:die("Target ped doesn't exist")
+    end
 
     RequestCollisionAtCoord(coords.xyz)
     while (not HasCollisionLoadedAroundEntity(pedId)) do

--- a/src/api/ped/client/setVisible.lua
+++ b/src/api/ped/client/setVisible.lua
@@ -5,7 +5,7 @@
 ---@public
 function API_Ped:setVisible(pedId, state)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
     
     SetEntityVisible(pedId, state)

--- a/src/api/ped/client/setWalkToPosition.lua
+++ b/src/api/ped/client/setWalkToPosition.lua
@@ -9,7 +9,7 @@
 ---@public
 function API_Ped:setWalkToPosition(pedId, coords, speed, duration, heading, distanceToSlide)
     if (not (DoesEntityExist(pedId))) then
-        return NCS:die("Target ped does not exists")
+        return NCS:die("Target ped doesn't exist")
     end
     
     TaskGoStraightToCoord(pedId, coords, speed, duration, heading, distanceToSlide)

--- a/src/api/vehicles/client/cleanVehicle.lua
+++ b/src/api/vehicles/client/cleanVehicle.lua
@@ -1,11 +1,11 @@
 ---clean
----@param vehicleEntity number
+---@param vehicleId number
 ---@public
-function API_Vehicles:clean(vehicleEntity)
-    if (not (DoesEntityExist(vehicleEntity))) then
-        return NCS:die("vehicleEntity does not exists")
+function API_Vehicles:clean(vehicleId)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
 
-    SetVehicleDirtLevel(vehicleEntity, 0.0)
-    WashDecalsFromVehicle(vehicleEntity, 1.0)
+    SetVehicleDirtLevel(vehicleId, 0.0)
+    WashDecalsFromVehicle(vehicleId, 1.0)
 end

--- a/src/api/vehicles/client/deleteVehicle.lua
+++ b/src/api/vehicles/client/deleteVehicle.lua
@@ -1,11 +1,11 @@
 ---delete
----@param vehicleEntity number
+---@param vehicleId number
 ---@public
-function API_Vehicles:delete(vehicleEntity)
-    if (not (DoesEntityExist(vehicleEntity))) then
-        return NCS:die("vehicleEntity does not exists")
+function API_Vehicles:delete(vehicleId)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
 
-    SetEntityAsMissionEntity(vehicleEntity, 0, 1)
-    DeleteVehicle(vehicleEntity)
+    SetEntityAsMissionEntity(vehicleId, 0, 1)
+    DeleteVehicle(vehicleId)
 end

--- a/src/api/vehicles/client/getDoorsStates.lua
+++ b/src/api/vehicles/client/getDoorsStates.lua
@@ -3,9 +3,10 @@
 ---@return number
 ---@public
 function API_Vehicles:getDoorsStates(vehicleId)
-    if (vehicleId) and (DoesEntityExist(vehicleId)) then
-        local state <const> = (GetVehicleDoorLockStatus(vehicleId))
-        return (state)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:die("vehicleEntity does not exists")
+
+    local state <const> = (GetVehicleDoorLockStatus(vehicleId))
+    return (state)
 end

--- a/src/api/vehicles/client/getFuelTank.lua
+++ b/src/api/vehicles/client/getFuelTank.lua
@@ -3,10 +3,11 @@
 ---@return number
 ---@public
 function API_Vehicles:getFuelTank(vehicleId)
-    if (vehicleId) then
-        ---@type number
-        local fuel <const> = GetVehicleHandlingFloat(vehicleId, "CHandlingData", "fPetrolTankVolume")
-        return (fuel)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:trace("Unable to find vehicle", 1)
+
+    ---@type number
+    local fuel <const> = GetVehicleHandlingFloat(vehicleId, "CHandlingData", "fPetrolTankVolume")
+    return (fuel)
 end

--- a/src/api/vehicles/client/getModel.lua
+++ b/src/api/vehicles/client/getModel.lua
@@ -3,10 +3,11 @@
 ---@return string
 ---@public
 function API_Vehicles:getModel(vehicleId)
-    if (vehicleId) then
-        ---@type string
-        local model = GetDisplayNameFromVehicleModel(GetEntityModel(vehicleId))
-        return (model)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:trace('Unable to find vehicle', 1)
+
+    ---@type string
+    local model = GetDisplayNameFromVehicleModel(GetEntityModel(vehicleId))
+    return (model)
 end

--- a/src/api/vehicles/client/getPlate.lua
+++ b/src/api/vehicles/client/getPlate.lua
@@ -3,10 +3,11 @@
 ---@return string
 ---@public
 function API_Vehicles:getPlate(vehicleId)
-    if (vehicleId) and (DoesEntityExist(vehicleId)) then
-        local plate <const> = (GetVehicleNumberPlateText(vehicleId))
-        return (plate)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:die("vehicleEntity does not exists")
+
+    local plate <const> = (GetVehicleNumberPlateText(vehicleId))
+    return (plate)
 end
 

--- a/src/api/vehicles/client/getSpeed.lua
+++ b/src/api/vehicles/client/getSpeed.lua
@@ -3,10 +3,11 @@
 ---@return number
 ---@public
 function API_Vehicles:getSpeed(vehicleId)
-    if (vehicleId) then
-        ---@type number
-        local speed <const> = (GetEntitySpeed(vehicleId) * 3.6) --Set speed to km/h
-        return (speed)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:trace("Unable to find vehicle", 1)
+
+    ---@type number
+    local speed <const> = (GetEntitySpeed(vehicleId) * 3.6) --Set speed to km/h
+    return (speed)
 end

--- a/src/api/vehicles/client/getVehicleStates.lua
+++ b/src/api/vehicles/client/getVehicleStates.lua
@@ -1,13 +1,14 @@
 ---getVehicleStates
----@param vehicleEntity number
+---@param vehicleId number
 ---@return table
 ---@public
-function API_Vehicles:getStates(vehicleEntity)
-    vehicleEntity = (vehicleEntity or 0) > 0 and vehicleEntity or GetVehiclePedIsIn(PlayerPedId())
+function API_Vehicles:getStates(vehicleId)
 
-    if (not (DoesEntityExist(vehicleEntity))) then
-        return NCS:trace("vehicleEntity does not exists or player is not in any vehicle", 5)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist or player is not in any vehicle")
     end
+
+    vehicleId = (vehicleId or 0) > 0 and vehicleId or GetVehiclePedIsIn(PlayerPedId())
     
     local vehicleState = {
         engineHealth = GetVehicleEngineHealth(vehicleEntity),

--- a/src/api/vehicles/client/lockVehicle.lua
+++ b/src/api/vehicles/client/lockVehicle.lua
@@ -3,8 +3,9 @@
 ---@return void
 ---@public
 function API_Vehicles:lockVehicle(vehicleId)
-    if (vehicleId) and (DoesEntityExist(vehicleId)) then
-        return SetVehicleDoorsLocked(vehicleId, 2)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:die("vehicleEntity does not exists")
+
+    return SetVehicleDoorsLocked(vehicleId, 2)
 end

--- a/src/api/vehicles/client/openAllDoor.lua
+++ b/src/api/vehicles/client/openAllDoor.lua
@@ -5,11 +5,11 @@
 ---@return void
 ---@public
 function API_Vehicles:openAllDoor(vehicleId, canBeClosed, instantly)
-    if (vehicleId) and (DoesEntityExist(vehicleId)) then
-        for i = 0, 5 do
-            SetVehicleDoorOpen(vehicleId, i, canBeClosed or false, instantly or false)
-        end
-    return
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:die("vehicleEntity does not exists")
+
+    for i = 0, 5 do
+        SetVehicleDoorOpen(vehicleId, i, canBeClosed or false, instantly or false)
+    end
 end

--- a/src/api/vehicles/client/openDoor.lua
+++ b/src/api/vehicles/client/openDoor.lua
@@ -6,8 +6,12 @@
 ---@return void
 ---@public
 function API_Vehicles:openDoor(vehicleId, doorId, canBeClosed, instantly)
-    if (vehicleId) and (DoesEntityExist(vehicleId)) then
-        return SetVehicleDoorOpen(vehicleId, doorId, canBeClosed or false, instantly or false)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:die("vehicleEntity does not exists")
+    if (doorId < 0 or doorId > 5) then
+        return NCS:die("Target door doesn't exist. Put a doorId between 0 and 5")
+    end
+
+    return SetVehicleDoorOpen(vehicleId, doorId, canBeClosed or false, instantly or false)
 end

--- a/src/api/vehicles/client/repairVehicle.lua
+++ b/src/api/vehicles/client/repairVehicle.lua
@@ -1,12 +1,12 @@
 ---repair
----@param vehicleEntity number
+---@param vehicleId number
 ---@public
-function API_Vehicles:repair(vehicleEntity)
-    if (not (DoesEntityExist(vehicleEntity))) then
-        return NCS:die("vehicleEntity does not exists")
+function API_Vehicles:repair(vehicleId)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
 
-    SetVehicleFixed(vehicleEntity)
-    SetVehicleDirtLevel(vehicleEntity, 0.0)
-    SetVehicleDeformationFixed(vehicleEntity)
+    SetVehicleFixed(vehicleId)
+    SetVehicleDirtLevel(vehicleId, 0.0)
+    SetVehicleDeformationFixed(vehicleId)
  end

--- a/src/api/vehicles/client/setFuel.lua
+++ b/src/api/vehicles/client/setFuel.lua
@@ -3,8 +3,9 @@
 ---@param fuel number
 ---@public
 function API_Vehicles:setFuel(vehicleId, fuel)
-    if (vehicleId) then
-        return SetVehicleFuelLevel(vehicleId, fuel)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:trace("Unable to find vehicle", 1)
+
+    return SetVehicleFuelLevel(vehicleId, fuel)
 end

--- a/src/api/vehicles/client/unlockVehicle.lua
+++ b/src/api/vehicles/client/unlockVehicle.lua
@@ -3,8 +3,9 @@
 ---@return void
 ---@public
 function API_Vehicles:unlockVehicle(vehicleId)
-    if (vehicleId) and (DoesEntityExist(vehicleId)) then
-        return SetVehicleDoorsLocked(vehicleId, 1)
+    if (not (DoesEntityExist(vehicleId))) then
+        return NCS:die("Target vehicle doesn't exist")
     end
-    NCS:die("vehicleEntity does not exists")
+
+    return SetVehicleDoorsLocked(vehicleId, 1)
 end


### PR DESCRIPTION
Hello,
I will explain you what I did :

First, I fix typo :
`Target ped/vehicles does not exists` → `Target ped/vehicle doesn't exist`
`vehicleEntity does not exists` / `Unable to find vehicle` → `Target vehicle doesn't exist` -- Like the pedId error

And then, I put the same conventions codes for every files for a better experience : 
`vehicleEntity` → `vehicleId` -- Cause it's `pedId`

And for finish I put the same conditions everywhere : 
```
    if (not (DoesEntityExist(vehicleId))) then
        return NCS:die("Target vehicle doesn't exist")
    end
```

I think it's better like this.