### PR TITLE
:sparkles: Add New Class Trigger's

### DIFF
--- a/src/class/NCSTrigger/client/_constructor.lua
+++ b/src/class/NCSTrigger/client/_constructor.lua
@@ -1,0 +1,58 @@
+local CurrentRequestId = 0;
+local Callbacks = {};
+local TriggerClient = {};
+
+NCSTrigger = {}
+
+--- @param object {event:string, cbk:any}
+Trigger:SetClient = function(object)
+  TriggerClient[object.event] = object.cbk;
+end;
+
+--- @param object {event:string}
+--- @param ... any
+Trigger:Client = function(object, ...)
+  if (TriggerClient[object.event]) then
+    TriggerClient[object.event](...);
+  else
+    TriggerEvent(object.event, ...);
+  end;
+end;
+
+--- @param object {event:string, data:object}
+--- @param ... any
+Trigger:Server = function(object, ...)
+  if (object.data and object.data[1] == "Callback") then
+    TriggerServerEvent('NCSFramework:Callback', object.event, object.data[2], ...);
+  else
+    TriggerServerEvent('NCSFramework:Server', object.event, ...);
+  end;
+end;
+
+--- @param object {event:string, cbk:any}
+--- @param ... any
+Trigger:Callback = function(object, ...)
+  Callbacks[CurrentRequestId] = object.cbk;
+  Trigger:Server({event = object.event, data = {"Callback", CurrentRequestId}}, ...);
+  if (CurrentRequestId < 65535) then
+    CurrentRequestId = CurrentRequestId + 1;
+  else
+    CurrentRequestId = 0;
+  end;
+end;
+
+--- @param requestId number
+--- @param ... any
+RegisterNetEvent('NCSFramework:Callback');
+AddEventHandler('NCSFramework:Callback', function(requestId, ...)
+  Callbacks[requestId](...);
+	Callbacks[requestId] = nil;
+end);
+
+
+--- @param event string
+--- @param ... any
+RegisterNetEvent('NCSFramework:Client');
+AddEventHandler('NCSFramework:Client', function(event, ...)
+  Trigger:Client({event = event}, ...)
+end);

--- a/src/class/NCSTrigger/client/cl_example.lua
+++ b/src/class/NCSTrigger/client/cl_example.lua
@@ -1,0 +1,16 @@
+RegisterCommand('TriggerTest', function()
+  
+  NCSTrigger:Callback({event = 'Test numero 1'}, function(text)
+    print(text);
+  end, 'Trigger Event\'s', 'By TheFRcRaZy');
+
+  Wait(2500);
+
+  NCSTrigger:Server({event = 'J\'envoie au server'}, 'Hey !!!');
+
+  Wait(2500);
+
+  NCSTrigger:SetClient({event = 'J\'envoie au client', cbk = function(value)
+    print(value);
+  end});
+end);

--- a/src/class/NCSTrigger/server/_constructor.lua
+++ b/src/class/NCSTrigger/server/_constructor.lua
@@ -1,0 +1,67 @@
+local Callbacks = {};
+local TriggerServer = {};
+
+NCSTrigger = {}
+
+--- @param object {event:string, cbk:any}
+Trigger:SetServer = function(object)
+  TriggerServer[object.event] = object.cbk;
+end;
+
+--- @param object {event:string}
+--- @param src any
+--- @param ... any
+Trigger:Server = function(object, src, ...)
+  if (TriggerServer[object.event]) then
+    TriggerServer[object.event](src, ...);
+  else
+    TriggerEvent(object.event, ...);
+  end;
+end;
+
+--- @param object {event:string, data:object}
+--- @param src any
+--- @param ... any
+Trigger:Client = function(object, src, ...)
+  if (object.data and object.data[1] == "Callback") then
+    TriggerClientEvent('NCSFramework:Callback', src, object.data[2], ...);
+  else
+    TriggerClientEvent('NCSFramework:Client', src, object.event, ...);
+  end;
+end;
+
+--- @param object {event:string, cbk:any}
+Trigger:SetCallback = function(object)
+  Callbacks[object.event] = object.cbk;
+end;
+
+--- @param object {event:string}
+--- @param src any
+--- @param cbk any
+--- @param ... any
+Trigger:Callback = function(object, src, cbk, ...)
+  if (Callbacks[object.event]) then
+    Callbacks[object.event](src, cbk, ...);
+  else
+    print(('[^4NCSFramework^7] ^1Error: ^2Server callback %s does not exist.^7'):format(object.event));
+  end;
+end;
+
+--- @param event string
+--- @param requestId number
+--- @param ... any
+RegisterNetEvent('NCSFramework:Callback');
+AddEventHandler('NCSFramework:Callback', function(event, requestId, ...)
+  local src = source;
+  Trigger:Callback({event = event}, src, function(...)
+    Trigger:Client({event = event, data = {"Callback", requestId}}, src, ...);
+  end, ...);
+end);
+
+--- @param event string
+--- @param ... any
+RegisterNetEvent('NCSFramework:Server');
+AddEventHandler('NCSFramework:Server', function(event, ...)
+  local src = source;
+  Trigger:Server({event = event}, src, ...);
+end);

--- a/src/class/NCSTrigger/server/sv_example.lua
+++ b/src/class/NCSTrigger/server/sv_example.lua
@@ -1,0 +1,12 @@
+NCSTrigger:SetCallback({event = 'Test numero 1', cbk = function(src, cbk, val1, val2)
+  print(src, cbk, val1, val2);
+
+  cbk('Ceci est un callback');
+end});
+
+
+NCSTrigger:SetServer({event = 'J\'envoie au server', cbk = function(src, text)
+  print(text);
+
+  Trigger:Client({event = 'J\'envoie au client'}, src or -1, text);
+end});


### PR DESCRIPTION
Added class named NCSTrigger with allows to put the Triggers all in one.
CLIENT
```lua
 NCSTrigger:Callback({event = 'Test numero 1'}, function(text)
    print(text);
  end, 'Trigger Event\'s', 'By TheFRcRaZy');

  NCSTrigger:Server({event = 'J\'envoie au server'}, 'Hey !!!');


  NCSTrigger:SetClient({event = 'J\'envoie au client', cbk = function(value)
    print(value);
  end});
  ```
  
  SERVER

```lua
NCSTrigger:SetCallback({event = 'Test numero 1', cbk = function(src, cbk, val1, val2)
  print(src, cbk, val1, val2);

  cbk('Ceci est un callback');
end});


NCSTrigger:SetServer({event = 'J\'envoie au server', cbk = function(src, text)
  print(text);

  Trigger:Client({event = 'J\'envoie au client'}, src or -1, text);
end});
```